### PR TITLE
種々のレイアウトの調整

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -2,6 +2,7 @@ class ActivitiesController < ApplicationController
   def index
     @activities = Activity.all_asc_by_passed_time
     @activity = Activity.new
+    @activity_history = ActivityHistory.new
   end
 
   def create

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,8 +1,8 @@
 class ActivitiesController < ApplicationController
-	def index
-		@activities = Activity.all_asc_by_passed_time
+  def index
+    @activities = Activity.all_asc_by_passed_time
     @activity = Activity.new
-	end
+  end
 
   def create
     @activity = Activity.new(activity_params)

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,6 +1,6 @@
 class ActivitiesController < ApplicationController
 	def index
-		@activities = Activity.all
+		@activities = Activity.all_asc_by_passed_time
     @activity = Activity.new
 	end
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -12,4 +12,16 @@ class Activity < ApplicationRecord
 
 		Time.current - latest_history_datetime
 	end
+
+  class << self
+    def all_asc_by_passed_time
+      ActivityHistory
+        .group(:activity_id)
+        .maximum(:acted_at) # {id: acted_at} のハッシュが返る
+        .sort_by {|_, v| v } # acted_at でソート
+        .reverse
+        .map(&:first) # idのみ取り出す
+        .map {|id| Activity.find(id) }
+    end
+  end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,17 +1,17 @@
 class Activity < ApplicationRecord
-	has_many :activity_histories
+  has_many :activity_histories
 
   validates :name, presence: true, uniqueness: true
 
-	def latest_history_datetime
-		activity_histories.order(acted_at: :desc).first&.acted_at
-	end
+  def latest_history_datetime
+    activity_histories.order(acted_at: :desc).first&.acted_at
+  end
 
-	def passed_time
+  def passed_time
     return -1 if latest_history_datetime.nil?
 
-		Time.current - latest_history_datetime
-	end
+    Time.current - latest_history_datetime
+  end
 
   class << self
     def all_asc_by_passed_time

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -1,13 +1,5 @@
 <h1>アクティビティ一覧</h1>
-<% @activities.each do |activity| %>
-  <h2><%= link_to activity.name, activity %></h2>
-  <p><%= format_time_diff(activity.passed_time) %></p>
-  <%= button_to "Done!",
-    {controller: 'activity_histories', action: 'create'},
-    {params:{activity_history: {activity_id: activity.id, acted_at: Time.current}}} %>
-<% end %>
 
-<h1>新規登録</h1>
 <%= form_with model: @activity do |form| %>
   <div>
     <% @activity.errors.full_messages.each do |message| %>
@@ -23,4 +15,14 @@
   <div>
     <%= form.submit "登録" %>
   </div>
+<% end %>
+
+<hr>
+
+<% @activities.each do |activity| %>
+  <h2><%= link_to activity.name, activity %></h2>
+  <p><%= format_time_diff(activity.passed_time) %></p>
+  <%= button_to "Done!",
+    {controller: 'activity_histories', action: 'create'},
+    {params:{activity_history: {activity_id: activity.id, acted_at: Time.current}}} %>
 <% end %>

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -23,7 +23,9 @@
 <% @activities.each do |activity| %>
   <h3><%= link_to activity.name, activity %></h3>
   <p><%= format_time_diff(activity.passed_time) %></p>
-  <%= button_to "Did it!",
-    {controller: 'activity_histories', action: 'create'},
-    {params:{activity_history: {activity_id: activity.id, acted_at: Time.current}}} %>
+  <%= form_with model: @activity_history do |form| %>
+    <%= form.hidden_field :activity_id, value: activity.id %>
+    <%= form.hidden_field :acted_at, value: Time.current %>
+    <%= form.submit "Did it!" %>
+  <% end %>
 <% end %>

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -1,5 +1,7 @@
-<h1>アクティビティ一覧</h1>
+<h1>TATTA?</h1>
+<p>あれから何日経った？がわかるアプリ</p>
 
+<h4>新規アクティビティ</h4>
 <%= form_with model: @activity do |form| %>
   <div>
     <% @activity.errors.full_messages.each do |message| %>
@@ -8,7 +10,6 @@
   </div>
 
   <div>
-    <%= form.label :name, "名前" %>
     <%= form.text_field :name %>
   </div>
 
@@ -20,9 +21,9 @@
 <hr>
 
 <% @activities.each do |activity| %>
-  <h2><%= link_to activity.name, activity %></h2>
+  <h3><%= link_to activity.name, activity %></h3>
   <p><%= format_time_diff(activity.passed_time) %></p>
-  <%= button_to "Done!",
+  <%= button_to "Did it!",
     {controller: 'activity_histories', action: 'create'},
     {params:{activity_history: {activity_id: activity.id, acted_at: Time.current}}} %>
 <% end %>

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -1,3 +1,4 @@
+<p><%= link_to "一覧に戻る", activities_path %></p>
 <h1><%= @activity.name %></h1>
 <%= form_with model: @activity_history do |form| %>
   <div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")
-  # root "articles#index"
+  root "activities#index"
   resources :activities
   resources :activity_histories
 end


### PR DESCRIPTION
- activities/index の新規登録を上に持ってきた
- activities/show に一覧に戻るリンクを配置
- activities/index の文言を色々調整
- root を activities#index に
- トップページの activity の並びを経過時間の昇順に変更
