### PR TITLE
activity 一覧取得処理のバグを解消

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,6 +1,6 @@
 class ActivitiesController < ApplicationController
   def index
-    @activities = Activity.all_asc_by_passed_time
+    @activities = Activity.all
     @activity = Activity.new
     @activity_history = ActivityHistory.new
   end
@@ -21,7 +21,7 @@ class ActivitiesController < ApplicationController
   end
 
   def destroy
-    
+
     @activity = Activity.find(params[:id])
     @activity.destroy
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -12,16 +12,4 @@ class Activity < ApplicationRecord
 
     Time.current - latest_history_datetime
   end
-
-  class << self
-    def all_asc_by_passed_time
-      ActivityHistory
-        .group(:activity_id)
-        .maximum(:acted_at) # {id: acted_at} のハッシュが返る
-        .sort_by {|_, v| v } # acted_at でソート
-        .reverse
-        .map(&:first) # idのみ取り出す
-        .map {|id| Activity.find(id) }
-    end
-  end
 end


### PR DESCRIPTION
all_asc_by_passed_time のロジックの誤りにより、activity history が1つもない activity はリストに表示されないようになってしまっていた。
