### PR TITLE
アクティビティ一覧のテーブル化&アクティビティ名の変更・削除機能の追加

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -20,6 +20,20 @@ class ActivitiesController < ApplicationController
     @activity_history = ActivityHistory.new
   end
 
+  def edit
+    @activity = Activity.find(params[:id])
+  end
+
+  def update
+    @activity = Activity.find(params[:id])
+    if @activity.update(activity_params)
+      redirect_to @activity, status: :see_other
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+
   def destroy
 
     @activity = Activity.find(params[:id])

--- a/app/views/activities/edit.html.erb
+++ b/app/views/activities/edit.html.erb
@@ -1,0 +1,12 @@
+<p><%= link_to "前に戻る", @activity %></p>
+<h1>アクティビティ名の編集</h1>
+<%= form_with model: @activity do |form| %>
+
+  <div>
+    <%= form.text_field :name %>
+  </div>
+
+  <div>
+    <%= form.submit "変更" %>
+  </div>
+<% end %>

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -27,38 +27,11 @@
       <tr>
         <td><%= link_to activity.name, activity %></td>
         <td><%= format_time_diff(activity.passed_time) %></td>
-        <td><%= link_to "削除", activity_path(activity), data: {
-              turbo_method: :delete,
-              turbo_confirm: "本当に削除してよろしいですか？",
-            } %> </td>
         <td><%= form_with model: @activity_history do |form| %>
               <%= form.hidden_field :activity_id, value: activity.id %>
               <%= form.hidden_field :acted_at, value: Time.current %>
               <%= form.submit "Did it!"  %></td>
             <% end %></td>
-        
       </tr>
     <% end %>
   </tbody>
-
-<%
-=begin
-%>
-
-<% @activities.each do |activity| %>
-  <h3><%= link_to activity.name, activity %></h3>
-  <p><%= format_time_diff(activity.passed_time) %></p>
-  <%= form_with model: @activity_history do |form| %>
-    <%= form.hidden_field :activity_id, value: activity.id %>
-    <%= form.hidden_field :acted_at, value: Time.current %>
-    <%= form.submit "Did it!" %>
-  <% end %>
-  <%= link_to "削除", activity_path(activity), data: {
-    turbo_method: :delete,
-    turbo_confirm: "本当に削除してよろしいですか？",
-  } %>
-<% end %>
-
-<%
-=end
-%>

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -20,6 +20,31 @@
 
 <hr>
 
+<table>
+  
+  <tbody>
+    <% @activities.each do |activity| %>
+      <tr>
+        <td><%= link_to activity.name, activity %></td>
+        <td><%= format_time_diff(activity.passed_time) %></td>
+        <td><%= link_to "削除", activity_path(activity), data: {
+              turbo_method: :delete,
+              turbo_confirm: "本当に削除してよろしいですか？",
+            } %> </td>
+        <td><%= form_with model: @activity_history do |form| %>
+              <%= form.hidden_field :activity_id, value: activity.id %>
+              <%= form.hidden_field :acted_at, value: Time.current %>
+              <%= form.submit "Did it!"  %></td>
+            <% end %></td>
+        
+      </tr>
+    <% end %>
+  </tbody>
+
+<%
+=begin
+%>
+
 <% @activities.each do |activity| %>
   <h3><%= link_to activity.name, activity %></h3>
   <p><%= format_time_diff(activity.passed_time) %></p>
@@ -33,3 +58,7 @@
     turbo_confirm: "本当に削除してよろしいですか？",
   } %>
 <% end %>
+
+<%
+=end
+%>

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -1,10 +1,10 @@
 <p><%= link_to "一覧に戻る", activities_path %></p>
 <h1><%= @activity.name %></h1>
-<p><%= link_to "アクティビティ名の編集", edit_activity_path(@activity) %></p>
-<p><%= link_to "アクティビティの削除", activity_path(@activity), data: {
-      turbo_method: :delete,
-      turbo_confirm: "本当に削除してよろしいですか？",
-    } %> </p>
+<%= link_to "アクティビティ名の編集", edit_activity_path(@activity) %>
+<%= link_to "アクティビティの削除", activity_path(@activity), data: {
+  turbo_method: :delete,
+  turbo_confirm: "本当に削除してよろしいですか？",
+} %> 
 <%= form_with model: @activity_history do |form| %>
   <div>
     <%= form.label :note, "メモ" %>

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -1,5 +1,10 @@
 <p><%= link_to "一覧に戻る", activities_path %></p>
 <h1><%= @activity.name %></h1>
+<p><%= link_to "アクティビティ名の編集", edit_activity_path(@activity) %></p>
+<p><%= link_to "アクティビティの削除", activity_path(@activity), data: {
+      turbo_method: :delete,
+      turbo_confirm: "本当に削除してよろしいですか？",
+    } %> </p>
 <%= form_with model: @activity_history do |form| %>
   <div>
     <%= form.label :note, "メモ" %>


### PR DESCRIPTION
- ホーム画面のアクティビティ一覧をテーブル化にして見やすく
- 各アクティビティの画面から名前の変更・削除機能の追加